### PR TITLE
making $searchTerm parameter as optional

### DIFF
--- a/google-search-results.php
+++ b/google-search-results.php
@@ -99,7 +99,7 @@ class GoogleSearchResults {
     return $this->httpPut("/live/batches/{$batchId}/{$searchId}", $params);
   }
     
-  function httpGet($decode_format, $output, $q, $path, $searchTerm) {
+  function httpGet($decode_format, $output, $q, $path, $searchTerm = NULL) {
     if($this->api_key == NULL) {
       throw new SerpWowException("api_key must be defined in the constructor");
     }


### PR DESCRIPTION
Made `$searchTerm` parameter optional to avoid warning and notice errors